### PR TITLE
Small styling tweaks to the search results

### DIFF
--- a/quickstart/frontend/src/components/org-search/OrgSearch.css
+++ b/quickstart/frontend/src/components/org-search/OrgSearch.css
@@ -31,10 +31,6 @@
         min-width: 3rem;
     }
 
-    & a {
-        color: white;
-    }
-
     & img {
         width: 40px;
         min-width: 40px;

--- a/quickstart/frontend/src/components/org-search/OrgSearch.tsx
+++ b/quickstart/frontend/src/components/org-search/OrgSearch.tsx
@@ -36,7 +36,7 @@ export const OrgSearch = () => {
           data?.pages.map((page) =>
             page.map((org) => (
               <div key={org.ein ?? org.id} className="org-listing">
-                <img src={org.logo} alt={org.logo ? org.name : ''} />
+                {org.logo && (<img src={org.logo} alt={org.logo ? org.name : ''} />)}
                 <a href={`${getEndaomentUrls().app}/orgs/${org.ein ?? org.id}`}>
                   {org.name}
                 </a>


### PR DESCRIPTION
I made these changes:
- Made removed the white text color CSS rule (so the org names were visible)
- Conditionally rendered the logo for cases where there isn't one

![CleanShot 2025-03-27 at 16 39 51@2x](https://github.com/user-attachments/assets/d7873821-2d1f-4368-bb3a-4259b39a1296)
